### PR TITLE
Fix canonical href with absolute path

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_BASE_DOMAIN_URL=https://dersu.uz

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Docker and Make required.
 
 Run `make` at the root folder and head off to http://localhost:4000 or use your IP in the local network to check on devices.
 
+### Local configuration
+
+Public variables can be defined in the `.env` file with default values that will be used in production.
+
+Those values can be overwriten locally with a `.env.local` file (git ignored).
+
 ## Continuous integration and deployment
 
 The Docker image for the Cloud Run service is built and deployed via Terraform on commits to the `main` branch.

--- a/src/constants/settings.js
+++ b/src/constants/settings.js
@@ -1,3 +1,6 @@
+/* global process*/
+
+export const BASE_DOMAIN_URL = process.env.NEXT_PUBLIC_BASE_DOMAIN_URL
 export const IUBENDA_ID = `82963742`
 export const IUBENDA_PRIVACY_API_URL = `https://www.iubenda.com/api/privacy-policy/${IUBENDA_ID}/no-markup`
 export const IUBENDA_PRIVACY_LINK = `<a href="https://www.iubenda.com/privacy-policy/${IUBENDA_ID}" class="iubenda-white no-brand iubenda-noiframe iubenda-embed iubenda-noiframe iub-body-embed" title="Privacy Policy">Privacy Policy</a>`

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,7 +2,11 @@ import React, { useEffect } from 'react'
 import { useRouter } from 'next/router'
 import { useCookie } from 'react-use'
 
-import { COOKIES_PREFERRED_LOCALE_NAME } from '@/constants/settings'
+import {
+  BASE_DOMAIN_URL,
+  COOKIES_PREFERRED_LOCALE_NAME,
+} from '@/constants/settings'
+
 import ImportedHomePage, {
   getStaticProps as importedGetStaticProps,
 } from './es'
@@ -13,7 +17,7 @@ export const getStaticProps = args => {
     ...staticProps,
     props: {
       ...staticProps.props,
-      canonicalUrl: 'https://dersu.uz/es/',
+      canonicalUrl: `${BASE_DOMAIN_URL}/es/`,
     },
   }
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -13,7 +13,7 @@ export const getStaticProps = args => {
     ...staticProps,
     props: {
       ...staticProps.props,
-      canonicalUrl: '/es',
+      canonicalUrl: 'https://dersu.uz/es/',
     },
   }
 }


### PR DESCRIPTION
- Fixed canonical href with absolute path. 

Seems like relative paths doesn't fit well. Canonical is used only in root page because it has the same content than Spanish home.